### PR TITLE
Fix toKey function

### DIFF
--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -23,7 +23,7 @@ export function stoi(s) {
  * @return {string} The converted result
  */
 export function toKey(str) {
-  return str.replace(/[^a-zA-Z0-9]+/, '')
+  return str.replace(/[^a-zA-Z0-9]+/g, '')
 }
 
 

--- a/src/utils/strings.test.js
+++ b/src/utils/strings.test.js
@@ -7,6 +7,7 @@ import {
   safePathSplit,
   testUuid,
   toTitleCase,
+  toKey,
 } from './strings'
 
 
@@ -107,5 +108,11 @@ describe('strings', () => {
     expect(safePathSplit('/a/')).toStrictEqual(['a'])
     expect(safePathSplit('/a/b')).toStrictEqual(['a', 'b'])
     expect(safePathSplit('/a/b/c')).toStrictEqual(['a', 'b', 'c'])
+  })
+
+  it('toKey removes non alphanumerics', () => {
+    expect(toKey('abc')).toBe('abc')
+    expect(toKey('a-b-c')).toBe('abc')
+    expect(toKey('a_b-c.d')).toBe('abcd')
   })
 })


### PR DESCRIPTION
## Summary
- fix `toKey` utility to remove all non-alphanumeric characters
- add regression tests for `toKey`

## Testing
- `node --experimental-vm-modules ./node_modules/.bin/jest --config tools/jest/jest-tools.config.js`
- `node ./node_modules/.bin/jest --config tools/jest/jest.config.js`
