### PR TITLE
Limit share options for unsaved models

### DIFF
--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -30,6 +30,9 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
   const setIsVersionsEnabled = useStore((state) => state.setIsVersionsEnabled)
   const repository = useStore((state) => state.repository)
   const setRepository = useStore((state) => state.setRepository)
+  const clearRepository = useStore((state) => state.clearRepository)
+  const setIsShareEnabled = useStore((state) => state.setIsShareEnabled)
+  const setIsNotesEnabled = useStore((state) => state.setIsNotesEnabled)
 
   useMemo(() => {
     if (isAppsEnabled) {
@@ -64,9 +67,16 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
     })
     onChangeUrlParams()
 
+    const isNewModel = pathPrefix.endsWith('/v/new')
+    setIsShareEnabled(!isNewModel)
+    setIsNotesEnabled(!isNewModel)
+
     // TODO(pablo): currently expect these to both be defined.
     const {org, repo} = urlParams
-    if (org && repo) {
+    if (isNewModel) {
+      clearRepository()
+      setIsVersionsEnabled(false)
+    } else if (org && repo) {
       setRepository(org, repo)
       setIsVersionsEnabled(true)
     } else if (pathPrefix.startsWith('/share/v/p')) {
@@ -76,7 +86,8 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
       debug().warn('No repository set for project!, ', pathPrefix)
     }
   }, [appPrefix, installPrefix, modelPath, navigate, pathPrefix,
-      setIsVersionsEnabled, setModelPath, setRepository, urlParams])
+      setIsVersionsEnabled, setModelPath, setRepository, urlParams,
+      setIsShareEnabled, setIsNotesEnabled, clearRepository])
 
 
   // https://mui.com/material-ui/customization/how-to-customize/#4-global-css-override

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -24,6 +24,7 @@ let commentDeleted = false
  */
 export function initHandlers(defines) {
   const handlers = []
+  handlers.push(...bldrsHandlers())
   handlers.push(...gaHandlers())
   handlers.push(...githubHandlers(defines, true))
   handlers.push(...githubHandlers(defines, false))
@@ -32,6 +33,22 @@ export function initHandlers(defines) {
   handlers.push(...subscribePageHandler())
   return handlers
 }
+
+
+/**
+ * @return {Array<object>} handlers
+ */
+function bldrsHandlers() {
+  return [
+    rest.get('http://bldrs.ai/icons/*', (req, res, ctx) => {
+      return res(
+          ctx.status(httpOk),
+          ctx.text(''),
+      )
+    }),
+  ]
+}
+
 
 /**
  * Handlers for Netlify functions

--- a/src/store/RepositorySlice.js
+++ b/src/store/RepositorySlice.js
@@ -27,5 +27,7 @@ export default function createRepositorySlice(set, get) {
         name: repo,
       },
     })),
+
+    clearRepository: () => set(() => ({repository: null})),
   }
 }


### PR DESCRIPTION
## Summary
- add `clearRepository` store action
- disable Share and Notes when viewing unsaved drag‑and‑drop models

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*