### PR TITLE
test: reset globals between tests

### DIFF
--- a/tools/bun/setupTests.js
+++ b/tools/bun/setupTests.js
@@ -264,6 +264,20 @@ afterEach(() => {
   } catch (e) {
     // Ignore if store is mocked in individual tests
   }
+
+  // Clear any values stored in localStorage between tests
+  if (global.localStorage && typeof global.localStorage.clear === 'function') {
+    global.localStorage.clear()
+  }
+
+  // Reset window location fields to their defaults
+  if (global.window && global.window.location) {
+    global.window.location.href = 'http://localhost/'
+    global.window.location.hash = ''
+    global.window.location.search = ''
+    global.window.location.pathname = '/'
+  }
+  // If other window properties are mutated, consider recreating the window object
 })
 
 // Clean up after the tests are finished.

--- a/tools/jest/setupTests.js
+++ b/tools/jest/setupTests.js
@@ -25,7 +25,21 @@ beforeAll(() => {
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  // Clear any values stored in localStorage between tests
+  if (global.localStorage && typeof global.localStorage.clear === 'function') {
+    global.localStorage.clear()
+  }
+  // Reset window location fields to their defaults
+  if (global.window && global.window.location) {
+    global.window.location.href = 'http://localhost/'
+    global.window.location.hash = ''
+    global.window.location.search = ''
+    global.window.location.pathname = '/'
+  }
+  // If other window properties are mutated, consider recreating the window object
+})
 
 // Clean up after the tests are finished.
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary
- Clear localStorage after each test
- Reset window.location fields between tests

## Testing
- `yarn test` *(fails: Cannot find module 'msw/node')*

------
https://chatgpt.com/codex/tasks/task_b_68a309f72aa0832d9838ac4838042533